### PR TITLE
Set reattestation flag

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -238,6 +238,7 @@ func (p *Plugin) Attest(stream nodeattestorv1.NodeAttestor_AttestServer) error {
 			AgentAttributes: &nodeattestorv1.AgentAttributes{
 				SpiffeId:       common.AgentID(p.config.trustDomain, hashEncoded),
 				SelectorValues: buildSelectors(hashEncoded),
+				CanReattest:    true,
 			},
 		},
 	})


### PR DESCRIPTION
TPMS are able to reattest the node. Set the flag so that the agent knows it can do so.