### PR TITLE
fix: Adds fix and test to cover fail-open file case for hash attests

### DIFF
--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -52,7 +52,6 @@ func Test_checkHashAllowed(t *testing.T) {
 				_ = f.Close()
 
 			} else {
-				// normal test: root is a directory
 				root = t.TempDir()
 				if tt.setupFile {
 					path := filepath.Join(root, tt.hashEncoded)

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -1,0 +1,76 @@
+package server
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_checkHashAllowed(t *testing.T) {
+	tests := []struct {
+		name        string
+		setupFile   bool
+		hashEncoded string
+		rootIsFile  bool
+		want        bool
+	}{
+		{
+			name:        "hash exists",
+			setupFile:   true,
+			hashEncoded: "example-hash-abc",
+			want:        true,
+		},
+		{
+			name:        "hash does not exist",
+			setupFile:   false,
+			hashEncoded: "not-an-example-hash",
+			want:        false,
+		},
+		{
+			// We don't want to be fail-open in the case the user
+			// makes the hash_path parameter a file instead of a directory
+			// Previously this would allow all hashes to attest
+			name:        "directory is erroneously a file",
+			setupFile:   false,
+			rootIsFile:  true,
+			hashEncoded: "example-hash-abc",
+			want:        false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var root string
+			if tt.rootIsFile {
+				f, err := os.CreateTemp("", "hashes")
+				if err != nil {
+					t.Fatalf("failed to create temp root file: %v", err)
+				}
+				root = f.Name()
+				_ = f.Close()
+
+			} else {
+				// normal test: root is a directory
+				root = t.TempDir()
+				if tt.setupFile {
+					path := filepath.Join(root, tt.hashEncoded)
+					if err := os.WriteFile(path, []byte{}, 0644); err != nil {
+						t.Fatalf("failed to create test file: %v", err)
+					}
+				}
+			}
+
+			if tt.setupFile {
+				path := filepath.Join(root, tt.hashEncoded)
+				if err := os.WriteFile(path, []byte(""), 0644); err != nil {
+					t.Fatalf("failed to create test file: %v", err)
+				}
+			}
+
+			got := checkHashAllowed(root, tt.hashEncoded)
+			assert.Equal(t, got, tt.want)
+		})
+	}
+}


### PR DESCRIPTION
Stumbled on a tricky edge case when configuring the plugin recently

I had accidentally configured the Server with  `plugin_data.hash_path` as a file `hashes` instead of a directory. This was a misreading of the documentation, but I was interested to see my Agent would successfully node attest despite this misconfiguration on my part.

After a bit of a digging, I believe this logic in the `Attest` method could be altered to safeguard against this happening

https://github.com/spiffe/spire-tpm-plugin/blob/6eb314139fdeceb0332de617b4c90c7c63d60bc1/pkg/server/server.go#L143-L148

The condition `!os.IsNotExist` correctly checks if files with the `hashEncoded` name exist in `hashPath`, but I do not think this fails in the same manner if `hashPath` is a file itself and will allow any hash to return `validEK = true`

This PR proposes a few small changes to guard against this

* Refactoring of the above logic into a method of its own (mainly for testing purposes)
* An explicit check that `hashPath` is a directory
* A unit test to exercise this functionality