### PR TITLE
feat: Makes TPM device path configurable per Agent

### DIFF
--- a/pkg/common/socket.go
+++ b/pkg/common/socket.go
@@ -1,0 +1,24 @@
+package common
+
+import (
+	"errors"
+	"net"
+
+	"github.com/google/go-attestation/attest"
+)
+
+type SocketChannel struct {
+	net.Conn
+}
+
+func (sc *SocketChannel) MeasurementLog() ([]byte, error) {
+	return nil, errors.New("Not implemented")
+}
+
+func OpenTPMSocket(socketPath string) (attest.CommandChannelTPM20, error) {
+	conn, err := net.Dial("unix", socketPath)
+	if err != nil {
+		return nil, err
+	}
+	return &SocketChannel{Conn: conn}, nil
+}


### PR DESCRIPTION
This change introduces `TPMPath` as a configurable parameter for the Agent plugin to set a non-standard device location for the TPM. If the path is not provided, it falls back to the default case

This is useful for using software TPMs (like `swtpm`) which often mount in alternative chardev locations to the standard `/dev/tpmrm0`, and can be used to avoid clashes between hardware and software TPMS in scenarios like testing and CI